### PR TITLE
Add uncertainty calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .vscode
 tests/__pycache__
+moi/.DS_Store


### PR DESCRIPTION
Updated Integrate.py with linear uncertainty calculations.

These are currently done at all flow levels. They are used in the iterative re-weighting of the residuals. Both of these could use additional consideration and testing at larger scale.

The calculated uncertainties are getting written out.