### PR TITLE
Check to see if executing in AWS

### DIFF
--- a/run_MOI.py
+++ b/run_MOI.py
@@ -63,7 +63,7 @@ def main():
         index_to_run=-235
 
     #data directories
-    if index_to_run == -235:
+    if index_to_run == -235 or type(os.environ.get("AWS_BATCH_JOB_ID")) != type(None):
         INPUT_DIR = Path("/mnt/data/input")
         FLPE_DIR = Path("/mnt/data/flpe")
         OUTPUT_DIR = Path("/mnt/data/output")


### PR DESCRIPTION
Simple one line change to determine if executing in AWS environment for AWS Batch executions that are not job arrays.